### PR TITLE
Convert example graphs in whitepaper to bipartite graphs.

### DIFF
--- a/visualizations/graph-description-embeddings.ts
+++ b/visualizations/graph-description-embeddings.ts
@@ -16,21 +16,22 @@
  */
 
 import * as d3 from 'd3';
-import { makeGraph, sleep } from '../utils';
+import { makeBipartiteGraph, sleep } from '../utils';
 
 
 export class GraphDescriptionEmbeddings {
   parent = d3.select('#graph-description-embeddings');
   svg = this.parent.append('svg');
   textHolder = this.parent.append('div').classed('lines', true);
-  numNodes = 5;
+  numProducers = 3;
+  numConsumers = 2;
   selectedEdgeIdx = 1;
   selectedNodeIdx = 1;
   nodes;
   links;
   global;
   constructor() {
-    const [nodes, links] = makeGraph(this.numNodes, this.numNodes * 2);
+    const [nodes, links] = makeBipartiteGraph(this.numProducers, this.numConsumers);
     this.nodes = nodes;
     this.links = links;
     const numEdgeEmbed = 8;

--- a/visualizations/graph-description.ts
+++ b/visualizations/graph-description.ts
@@ -17,15 +17,16 @@
 
 
 import * as d3 from 'd3';
-import { makeGraph, sleep } from '../utils';
+import { makeBipartiteGraph, sleep } from '../utils';
 
 
 export class GraphDescription {
   parent = d3.select('#graph-description');
   svg = this.parent.append('svg');
-  numNodes = 5;
+  numProducers = 3;
+  numConsumers = 2;
   constructor() {
-    const [nodes, links] = makeGraph(this.numNodes, this.numNodes * 2);
+    const [nodes, links] = makeBipartiteGraph(this.numProducers, this.numConsumers);
     this.showGraph(nodes, links);
     this.showText();
   }

--- a/visualizations/graph-helpers.js
+++ b/visualizations/graph-helpers.js
@@ -1,0 +1,71 @@
+import * as d3 from 'd3'
+
+/**
+ * Creates a fully connected bipartite graph with nodes in left and right sets
+ * @param {number} leftCount Number of nodes in the left set
+ * @param {number} rightCount Number of nodes in the right set
+ * @param {Object} options Optional configuration
+ * @returns {Object} Object containing nodes and links arrays
+ */
+export function createBipartiteGraph(leftCount = 2, rightCount = 3, options = {}) {
+  const numEmbed = options.numEmbed || 8;
+  // Alternative palette
+  // var colorsV = ["#b5d9ea", "#c1d5e0", "#86bfe2", "#8facc6", "#76b6d6", "#c5e9f9", "#b5d9ea", "#c1d5e0", "#86bfe2", "#8facc6", "#76b6d6", "#c5e9f9", "#b5d9ea", "#c1d5e0", "#86bfe2", "#8facc6", "#76b6d6", "#c5e9f9", "#b5d9ea", "#c1d5e0", "#86bfe2", "#8facc6", "#76b6d6", "#c5e9f9"]
+  const colors = options.colors || ["#f2b200", "#c69700", "#ffeaa9", "#ffd255", "#d19f00", "#edc949", "#f2b200", "#c69700", "#ffeaa9", "#ffd255", "#d19f00", "#edc949", "#f2b200", "#c69700", "#ffeaa9", "#ffd255", "#d19f00", "#edc949"];
+
+  // Create nodes for both sets
+  const nodes = [];
+
+  // Create left set nodes
+  for (let i = 0; i < leftCount; i++) {
+    const node = {
+      v: i,
+      i: i,
+      isNode: true,
+      color: d3.color(colors[i % colors.length]),
+      neighbors: [],
+      set: 'left'
+    };
+
+    node.embed = d3.range(numEmbed).map(d => .05 + Math.random()*.95).map((v, i) => ({node, v, i}));
+    node.outembed = d3.range(numEmbed).map(d => .05 + Math.random()*.95).map((v, i) => ({node, v, i}));
+
+    nodes.push(node);
+  }
+
+  // Create right set nodes
+  for (let i = 0; i < rightCount; i++) {
+    const node = {
+      v: i + leftCount,
+      i: i + leftCount,
+      isNode: true,
+      color: d3.color(colors[(i + leftCount) % colors.length]),
+      neighbors: [],
+      set: 'right'
+    };
+
+    node.embed = d3.range(numEmbed).map(d => .05 + Math.random()*.95).map((v, i) => ({node, v, i}));
+    node.outembed = d3.range(numEmbed).map(d => .05 + Math.random()*.95).map((v, i) => ({node, v, i}));
+
+    nodes.push(node);
+  }
+
+  // Create links between every node in left set and every node in right set
+  const leftNodes = nodes.filter(node => node.set === 'left');
+  const rightNodes = nodes.filter(node => node.set === 'right');
+
+  const links = d3.cross(leftNodes, rightNodes)
+    .map(([a, b]) => {
+      const [i, j] = [a.i, b.i];
+      const color = colors[(i+j) % colors.length];
+      const linkId = i + ' ' + j;
+
+      // Connect nodes
+      a.neighbors.push(b);
+      b.neighbors.push(a);
+
+      return {a, b, linkId, v: 1, color: d3.color(color)};
+    });
+
+  return { nodes, links };
+}

--- a/visualizations/layerwise_trace.ts
+++ b/visualizations/layerwise_trace.ts
@@ -17,7 +17,7 @@
 
 
 import * as d3 from 'd3';
-import {makeGraph, sleep} from '../utils';
+import {makeBipartiteGraph, sleep} from '../utils';
 
 const hexColor = ["#f2b200", "#c69700", "#ffeaa9", "#ffd255", "#d19f00", "#edc949", "#f2b200", "#c69700", "#ffeaa9", "#ffd255", "#d19f00", "#edc949", "#f2b200", "#c69700", "#ffeaa9", "#ffd255", "#d19f00", "#edc949"]
 const color = hexColor.map(c => d3.color(c))
@@ -25,11 +25,12 @@ const color = hexColor.map(c => d3.color(c))
 export class LayerwiseTrace {
   parent = d3.select('#layerwise-trace');
   numLayers = 4;
-  numNodes = 5;
+  numProducers = 3;
+  numConsumers = 2;
   highlightCancelled = false;
   zIdxCounter = 0;
   constructor() {
-    const [nodes, links] = makeGraph(this.numNodes, this.numNodes*2);
+    const [nodes, links] = makeBipartiteGraph(this.numProducers, this.numConsumers);
     for (let layer=this.numLayers-1; layer>-1; layer--){
       this.showGraph(nodes, links, layer);
     }

--- a/visualizations/node-attributes.js
+++ b/visualizations/node-attributes.js
@@ -21,6 +21,7 @@ import * as d3_jp from 'd3-jetpack'
 import * as _ from 'underscore'
 import {swoopyDrag} from '../third_party/swoopy-drag'
 import { random } from '../utils';
+import { createBipartiteGraph } from './graph-helpers'
 
 export function nodeAttributes() {
   var width = 150
@@ -31,33 +32,14 @@ export function nodeAttributes() {
   var numEmbed = 8
   var sel = d3.select('#node-attributes').html('')
 
-  var nodes = window.stepNodes = window.stepNodes || d3.range(5).map((v, i) => {
+  var { nodes, links } = window.stepNodes = window.stepNodes ||
+    createBipartiteGraph(3, 2, {
+      numEmbed: numEmbed
+    });
 
-    var color = ["#f2b200", "#c69700", "#ffeaa9", "#ffd255", "#d19f00", "#edc949", "#af7aa1", "#ff9da7", "#9c755f", "#bab0ab"][i]
-    var rv = {v, i, isNode: true, color: d3.color(color), neighbors: []}
-    rv.embed = d3.range(numEmbed).map(d => .05 + Math.random()*.95).map((v, i) => ({node: rv, v, i}))
-    rv.outembed = d3.range(numEmbed).map(d => .05 + Math.random()*.95).map((v, i) => ({node: rv, v, i}))
-    
-    return rv
-  })
-
+  window.stepLinks = window.stepLinks || links;
 
   var n = nodes.length
-
-  var links = window.stepLinks = window.stepLinks || d3.cross(nodes, nodes)
-    .map(([a, b]) => {
-      var [i, j] = [a.i, b.i]
-      if (i <= j) return 
-
-      var linkId = i + ' ' + j
-      var v = random[i] < .3 ? 1 : 0
-      if (v){
-        nodes[i].neighbors.push(nodes[j])
-        nodes[j].neighbors.push(nodes[i])
-      }
-      return {a, b, linkId, v}
-    })
-    .filter(d => d)
 
   var renderFns = []
   function render(){
@@ -84,7 +66,7 @@ export function nodeAttributes() {
       d.pathStr = 'M' + [d.a, d.b].map(d => d.pos).join('L')
     })
 
-    var linkSel = g.append('g').appendMany('path.link', links.filter(d => d.a.i > d.b.i))
+    var linkSel = g.append('g').appendMany('path.link', links)
       .at({
         d: d => d.pathStr,
         strokeWidth: 2,

--- a/visualizations/node-step-small.js
+++ b/visualizations/node-step-small.js
@@ -156,47 +156,65 @@ export function nodeStepSmall() {
   }
 
   function addAnnotations(){
-  var isDrag = 0
+    var isDrag = 0
 
-const annotations = [
-  {
-    "text": "Aggregate information from adjacent edges",
-    "textOffset": [
-      189,
-      228
+    const annotations = [
+      {
+        "text": "Aggregate information from adjacent edges",
+        "textOffset": [
+          189,
+          228
+        ]
+      },
+      {
+        "path": "M 114,60 A 35.044 35.044 0 0 0 160,109",
+        "srcIndex": 0
+      },
+      {
+        "path": "M 52,51 A 80.808 80.808 0 0 0 183,145",
+        "srcIndex": 1
+      },
+      {
+        "path": "M 22,13 A 114.114 114.114 0 0 0 190,161",
+        "srcIndex": 2
+      },
+
+      {
+        "path": "M 140,32 A 43.963 43.963 0 0 1 189,35",
+        "srcIndex": 3
+      },
+      {
+        "path": "M 84,72 A 58.95 58.95 0 0 0 175,129",
+        "srcIndex": 4
+      },
+      {
+        "path": "M 63,18 A 78.02 78.02 0 0 1 219,14",
+        "srcIndex": 5
+      }
     ]
-  },
-  {
-    "path": "M 114,60 A 35.044 35.044 0 0 0 160,109",
-    "srcIndex": 0
-  },
-  {
-    "path": "M 52,51 A 80.808 80.808 0 0 0 183,145",
-    "srcIndex": 1
-  },
-  {
-    "path": "M 22,13 A 114.114 114.114 0 0 0 190,161",
-    "srcIndex": 2
-  },
+    // Calculate graph translation offset (using initial xOffset = 0)
+    const gTranslate = [width/2, height/2 - 60];
 
-  {
-    "path": "M 140,32 A 43.963 43.963 0 0 1 189,35",
-    "srcIndex": 3
-  },
-  {
-    "path": "M 84,72 A 58.95 58.95 0 0 0 175,129",
-    "srcIndex": 4
-  },
-  {
-    "path": "M 63,18 A 78.02 78.02 0 0 1 219,14",
-    "srcIndex": 5
-  }
-]
-  var swoopy = swoopyDrag()
-      .x(d => 0)
-      .y(d => 0)
-      .draggable(isDrag)
-      .annotations(annotations)
+    // Update annotation paths to originate from link midpoints
+    annotations.forEach(d => {
+      if (d.srcIndex !== undefined && d.path) {
+        const link = links[d.srcIndex];
+        if (link && link.a && link.b && link.a.pos && link.b.pos) {
+          const midX = (link.a.pos[0] + link.b.pos[0]) / 2 + gTranslate[0];
+          const midY = (link.a.pos[1] + link.b.pos[1]) / 2 + gTranslate[1];
+          // Replace the M x,y part of the path string
+          d.path = d.path.replace(/^M\s*[^\s,]+[\s,]+[^\sA]+/, `M ${midX.toFixed(1)},${midY.toFixed(1)}`);
+        } else {
+           console.warn(`Skipping annotation path update for srcIndex ${d.srcIndex}: Link or positions missing`);
+        }
+      }
+    });
+
+    var swoopy = swoopyDrag()
+        .x(d => 0)
+        .y(d => 0)
+        .draggable(isDrag)
+        .annotations(annotations)
 
     var swoopySel = c.svg.append('g.annotations').call(swoopy)
 

--- a/visualizations/node-step-small.js
+++ b/visualizations/node-step-small.js
@@ -21,6 +21,7 @@ import * as d3_jp from 'd3-jetpack'
 import * as _ from 'underscore'
 import {swoopyDrag} from '../third_party/swoopy-drag'
 import { random } from '../utils';
+import { createBipartiteGraph } from './graph-helpers'
 
 export function nodeStepSmall() {
   var width = 150
@@ -30,35 +31,14 @@ export function nodeStepSmall() {
   var numEmbed = 8
   var sel = d3.select('#node-step-small').html('')
 
-  // Alternative palette
-  // var colorsV = ["#b5d9ea", "#c1d5e0", "#86bfe2", "#8facc6", "#76b6d6", "#c5e9f9", "#b5d9ea", "#c1d5e0", "#86bfe2", "#8facc6", "#76b6d6", "#c5e9f9", "#b5d9ea", "#c1d5e0", "#86bfe2", "#8facc6", "#76b6d6", "#c5e9f9", "#b5d9ea", "#c1d5e0", "#86bfe2", "#8facc6", "#76b6d6", "#c5e9f9"]
-  var colorsN = ["#f2b200", "#c69700", "#ffeaa9", "#ffd255", "#d19f00", "#edc949"]
-  var colorsV = ["#f2b200", "#c69700", "#ffeaa9", "#ffd255", "#d19f00", "#edc949", "#f2b200", "#c69700", "#ffeaa9", "#ffd255", "#d19f00", "#edc949", "#f2b200", "#c69700", "#ffeaa9", "#ffd255", "#d19f00", "#edc949"]
-  var nodes = window.stepNodesSm = window.stepNodesSm || d3.range(5).map((v, i) => {
+  var { nodes, links } = window.stepNodesSm = window.stepNodesSm ||
+    createBipartiteGraph(3, 2, {
+      numEmbed: numEmbed
+    });
 
-    var rv = {v, i, isNode: true, color: d3.color(colorsN[i]), neighbors: []}
-    rv.embed = d3.range(numEmbed).map(d => .05 + Math.random()*.95).map((v, i) => ({node: rv, v, i}))
-    rv.outembed = d3.range(numEmbed).map(d => .05 + Math.random()*.95).map((v, i) => ({node: rv, v, i}))
-    return rv
-  })
-
+  window.stepLinksSm = window.stepLinksSm || links;
 
   var n = nodes.length
-
-  var links = window.stepLinksSm = window.stepLinksSm || d3.cross(nodes, nodes)
-    .map(([a, b]) => {
-      var [i, j] = [a.i, b.i]
-      if (i <= j) return
-      var color = colorsV[i+j] // this will have repeats, that's ok.
-      var linkId = i + ' ' + j
-      var v = random[i] < .3 ? 1 : 0
-      if (v){
-        nodes[i].neighbors.push(nodes[j])
-        nodes[j].neighbors.push(nodes[i])
-        return {a, b, linkId, v, color: d3.color(color)}
-      }
-    })
-    .filter(d => d)
 
   var renderFns = []
   function render(){
@@ -85,7 +65,7 @@ export function nodeStepSmall() {
       d.pathStr = 'M' + [d.a, d.b].map(d => d.pos).join('L')
     })
 
-    var linkSel = g.append('g').appendMany('path.link', links.filter(d => d.a.i > d.b.i))
+    var linkSel = g.append('g').appendMany('path.link', links)
       .at({
         d: d => d.pathStr,
         strokeWidth: 2,
@@ -210,11 +190,7 @@ const annotations = [
   {
     "path": "M 63,18 A 78.02 78.02 0 0 1 219,14",
     "srcIndex": 5
-  },
-  {
-    "path": "M 95,-21 A 70.374 70.374 0 0 1 204,26",
-    "srcIndex": 6
-  },
+  }
 ]
   var swoopy = swoopyDrag()
       .x(d => 0)

--- a/visualizations/node-step.js
+++ b/visualizations/node-step.js
@@ -15,13 +15,12 @@
  * =============================================================================
  */
 
-
 import * as d3 from 'd3'
 import * as d3_jp from 'd3-jetpack'
 import * as _ from 'underscore'
 import {swoopyDrag} from '../third_party/swoopy-drag'
 import { random } from '../utils';
-
+import { createBipartiteGraph } from './graph-helpers'
 export function nodeStep() {
   var width = 150
   var barWidth = 100
@@ -31,33 +30,10 @@ export function nodeStep() {
   var numEmbed = 8
   var sel = d3.select('#node-step').html('')
 
-  var nodes = window.stepNodes = window.stepNodes || d3.range(5).map((v, i) => {
-
-    var color = ["#f2b200", "#c69700", "#ffeaa9", "#ffd255", "#d19f00", "#edc949", "#af7aa1", "#ff9da7", "#9c755f", "#bab0ab"][i]
-    var rv = {v, i, isNode: true, color: d3.color(color), neighbors: []}
-    rv.embed = d3.range(numEmbed).map(d => .05 + Math.random()*.95).map((v, i) => ({node: rv, v, i}))
-    rv.outembed = d3.range(numEmbed).map(d => .05 + Math.random()*.95).map((v, i) => ({node: rv, v, i}))
-
-    return rv
-  })
-
-
+  var { nodes, links } = createBipartiteGraph(3, 2);
+  window.stepNodes = nodes;
+  window.stepLinks = window.stepLinks || links;
   var n = nodes.length
-
-  var links = window.stepLinks = window.stepLinks || d3.cross(nodes, nodes)
-    .map(([a, b]) => {
-      var [i, j] = [a.i, b.i]
-      if (i <= j) return 
-
-      var linkId = i + ' ' + j
-      var v = random[i] < .3 ? 1 : 0
-      if (v){
-        nodes[i].neighbors.push(nodes[j])
-        nodes[j].neighbors.push(nodes[i])
-      }
-      return {a, b, linkId, v}
-    })
-    .filter(d => d)
 
   var renderFns = []
   function render(){
@@ -88,7 +64,7 @@ export function nodeStep() {
       d.pathStr = 'M' + [d.a, d.b].map(d => d.pos).join('L')
     })
 
-    var linkSel = g.append('g').appendMany('path.link', links.filter(d => d.a.i > d.b.i))
+    var linkSel = g.append('g').appendMany('path.link', links)
       .at({
         d: d => d.pathStr,
         strokeWidth: 2,
@@ -375,8 +351,3 @@ if (module.hot) {
   nodeStep()
   module.hot.accept()
 }
-
-
-
-
-


### PR DESCRIPTION
I was reading through the whitepaper, and noted the use of bipartite graphs. I was confused and then sad to notice that none of the example graphs were bipartite, so I decided to fix them.

These changes maintain all of the functionality that was present before, with some minor tweaks. The nodes and edges still highlight with all the same color schemes, except the node-step-small responsible for the visualization of the transaction proofs has had one edge/attribute removed. Luckily, only that one edge was necessary to remove to make the graph bipartite. The graphs constructed prior to that were random, and the attributes seemed constructed around the results given some seed post hoc. Now the bipartite graphs are constructed as complete using the normal Kn,m specification.

![image](https://github.com/user-attachments/assets/1fc09c99-8226-4ab2-a9d1-323659a05a46)
